### PR TITLE
给主题添加关键字，方便SEO

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -18,6 +18,12 @@
       title = 'Tag: ' + page.tag;
   %>
   <title><% if (title) { %><%= title %> | <% } %><%= config.title %></title>
+  <% if (page.keywords){ %>
+	<meta name="keywords" content="<%= page.keywords %>,<%= config.keywords %>">
+	<% } else if (config.keywords){ %>
+	<meta name="keywords" content="<%= config.keywords %>">
+	<%} 
+  %>
   <meta name="HandheldFriendly" content="True" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <%- favicon_tag(config.favicon) %>


### PR DESCRIPTION
在站点配置_config.yml添加keywords: 关键字1,关键字2,...（关键字之间用逗号隔开）
也可以在markdown文章头部添加关键字 keywords: 关键字1,关键字2,...（关键字之间用逗号隔开）
然后hexo g 
可以F12查看[public/index.html](https://wildgrass.top)文件，寻找：
`<meta name="keywords" content="关键字1,关键字2，..."> `
本人亲测有效，无错误。