### PR TITLE
MathJax和加友链自动添加URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,10 @@ google_fonts: 'Ubuntu|Ubuntu+Mono' # 多个字体中间用英文竖线隔开
 # style: material    # 导航栏和标题栏背景是主题色
 style: pure        # 导航栏和标题栏背景是白色
 
+# 在摘要页面加载MathJax，设置为true在点击“读全文之”之前加载MathJax，
+# WARNNING: 设置为true对性能会有影响，这回使得打开网站比较慢，
+# 如果你确定不在阅“读全文之”前放MathJax公式，请将此选项设置为false。
+abstract_mathjax: false
 
 # 右边的小窗口，不想显示哪一项的把enable设置为false即可
 widgets:

--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -14,7 +14,3 @@
 		总访问量为 <span id="busuanzi_value_site_pv"><i class="fas fa-spinner fa-spin fa-fw" aria-hidden="true"></i></span> 次。
     </div>
 </footer>
-<!-- 根据页面mathjax变量决定是否加载MathJax数学公式js -->
-<% if (page.mathjax){ %>
-    <%- partial('mathjax') %>
-<% } %>

--- a/layout/_partial/post.ejs
+++ b/layout/_partial/post.ejs
@@ -43,3 +43,7 @@
         <% } %>
     </section>
 </article>
+<!-- 在摘要部分加载 MathJax 数学公式js -->
+<% if (theme.abstract_mathjax){ %>
+    <%- partial('mathjax') %>
+<% } %>

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -187,3 +187,7 @@
   });
 </script>
 <% } %>
+<!-- 根据页面mathjax变量决定是否加载MathJax数学公式js -->
+<% if (page.mathjax){ %>
+    <%- partial('mathjax') %>
+<% } %>

--- a/layout/_widget/links.ejs
+++ b/layout/_widget/links.ejs
@@ -2,7 +2,7 @@
     <header class='header <%= theme.style %>'>
         <div><i class="<%= theme.widgets.links.icon %> fa-fw" aria-hidden="true"></i>&nbsp;&nbsp;<%= theme.widgets.links.title %></div>
         <% if(config.title && theme.widgets.links.mailto) { %>
-            <a class="rightBtn" title="联系博主添加友链" target="_blank" rel="external nofollow noopener noreferrer" href="mailto:<%= theme.widgets.links.mailto %>?subject=交换友链&body=你好，我想和你交换友链，我已经将【<%= config.title %>】添加到我的博客的友链中。我的博客链接是："><i class="fas fa-plus fa-fw"></i></a>
+            <a class="rightBtn" title="联系博主添加友链" target="_blank" rel="external nofollow noopener noreferrer" href="mailto:<%= theme.widgets.links.mailto %>?subject=交换友链&body=你好，我想和你交换友链，我已经将【<%= config.title %>】添加到我的博客的友链中。我的博客链接是：<%= config.url %>"><i class="fas fa-plus fa-fw"></i></a>
         <%} %>
     </header>
     <div class='content <%= theme.style %>'>


### PR DESCRIPTION
添加了摘要部分（点击“阅读全文”之前显示的内容）的mathjax支持，修复了上传到github后MathJax数学公式不渲染的问题。增加了发邮件加友链时自动将自己网站（博客）的url附在邮件模版中这一便捷的功能。