### PR TITLE
MathJax和友链邮件模版

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,9 @@ google_fonts: 'Ubuntu|Ubuntu+Mono' # 多个字体中间用英文竖线隔开
 # style: material    # 导航栏和标题栏背景是主题色
 style: pure        # 导航栏和标题栏背景是白色
 
+# 是否在archive（主页、分类、归档和标签页）中针对摘要部分的MathJax公式加载mathjax.js文件
+# 对网站加载速度略有影响，如果你确定不会在阅“读全文之”前放置数学公式，请将此选项设置为false。
+abstract_mathjax: false
 
 # 右边的小窗口，不想显示哪一项的把enable设置为false即可
 widgets:

--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -46,3 +46,20 @@
     </div>
 
 <% } %>
+
+<!-- 根据主题中的设置决定是否在archive中针对摘要部分的MathJax公式加载mathjax.js文件 -->
+<% if (theme.abstract_mathjax){ %>
+    <%
+    var need_mathjax = false;
+    page.posts.each(function(post){
+        if (post.mathjax){
+            need_mathjax = true;
+        }
+    });
+    %>
+
+    <% if (need_mathjax){ %>
+        <%- partial('mathjax') %>
+    <% } %>
+
+<% } %>

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -124,6 +124,11 @@
 
 </article>
 
+<!-- 根据页面mathjax变量决定是否加载MathJax数学公式js -->
+<% if (page.mathjax){ %>
+    <%- partial('mathjax') %>
+<% } %>
+
 <br>
 
 <!-- 显示推荐文章和评论 -->

--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -14,7 +14,3 @@
 		总访问量为 <span id="busuanzi_value_site_pv"><i class="fas fa-spinner fa-spin fa-fw" aria-hidden="true"></i></span> 次。
     </div>
 </footer>
-<!-- 根据页面mathjax变量决定是否加载MathJax数学公式js -->
-<% if (page.mathjax){ %>
-    <%- partial('mathjax') %>
-<% } %>

--- a/layout/_widget/links.ejs
+++ b/layout/_widget/links.ejs
@@ -2,7 +2,7 @@
     <header class='header <%= theme.style %>'>
         <div><i class="<%= theme.widgets.links.icon %> fa-fw" aria-hidden="true"></i>&nbsp;&nbsp;<%= theme.widgets.links.title %></div>
         <% if(config.title && theme.widgets.links.mailto) { %>
-            <a class="rightBtn" title="联系博主添加友链" target="_blank" rel="external nofollow noopener noreferrer" href="mailto:<%= theme.widgets.links.mailto %>?subject=交换友链&body=你好，我想和你交换友链，我已经将【<%= config.title %>】添加到我的博客的友链中。我的博客链接是："><i class="fas fa-plus fa-fw"></i></a>
+            <a class="rightBtn" title="联系博主添加友链" target="_blank" rel="external nofollow noopener noreferrer" href="mailto:<%= theme.widgets.links.mailto %>?subject=交换友链&body=你好，我想和你交换友链，我已经将【<%= config.title %>】添加到我的博客的友链中。我的博客链接是：<%= config.url %>"><i class="fas fa-plus fa-fw"></i></a>
         <%} %>
     </header>
     <div class='content <%= theme.style %>'>


### PR DESCRIPTION
解决了上传到网站的页面中MathJax公式不会被渲染的问题；添加了摘要页面的MathJax支持；在加友链的邮件模版中加入了网站的URL。