### PR TITLE
增加字数统计、阅读时长

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,9 @@ avatar_placeholder: https://cdn.jsdelivr.net/gh/xaoxuu/assets@master/avatar/avat
 date_format: 'YYYY-MM-DD' # 文章发布日期的格式
 updated_date_format: 'll' # 文章更新日期的格式
 
+# 文章字数统计、阅读时长，默认关闭，开启需要安装插件: npm i --save hexo-wordcount
+word_count: false
+
 # 幻灯片
 backstretch:
   position: cover  # cover: 封面背景   full: 整个网页背景
@@ -127,7 +130,7 @@ layout:
   # 文章列表（主页、自定义的列表）布局
   posts:
     # 列表中每一篇文章的meta信息
-    meta: [title, author, date, categories, top]
+    meta: [title, author, date, categories, wordcount, top]
     # 列表类页面的侧边栏
     sidebar: [author, plain, list, grid, category, tagcloud]
   # 文章页面布局
@@ -137,7 +140,7 @@ layout:
     # 默认的meta信息，文章中没有配置则按照这里的配置来显示，设置为false则不显示
     # 其中，title只在header中有效，music和thumbnail无需在这里设置，文章中有则显示
     # 如果tags放置在meta.header中，那么在post列表中不显示（因为卡片下方已经有了）
-    header: [title, author, date, categories, counter, top]
+    header: [title, author, date, categories, counter, wordcount, top]
     footer: [updated, tags, share]
     # 文章页面的侧边栏
     sidebar: [author, plain, toc, grid, category, tagcloud, list, related_posts]

--- a/layout/_meta/wordcount.ejs
+++ b/layout/_meta/wordcount.ejs
@@ -1,0 +1,18 @@
+<% if(isPostList || !isPostList){ %>
+  <% if (theme.word_count && !post.no_word_count) { %>
+    <div class="new-meta-item wordcount">
+      <a class='notlink'>
+        <i class="fas fa-keyboard" aria-hidden="true"></i>
+        <p>字数统计:</p>
+        <p><%= wordcount(post.content) %>字</p>
+      </a>
+    </div>
+    <div class="new-meta-item readtime">
+      <a class='notlink'>
+        <i class="fas fa-hourglass-half" aria-hidden="true"></i>
+        <p>阅读时长≈</p>
+        <p><%= min2read(post.content) %>分</p>
+      </a>
+    </div>
+  <% } %>
+<% } %>


### PR DESCRIPTION
增加字数统计、阅读时长显示，用户可以通过主题配置里 `word_count` 关键字来选择是否开启此功能，默认 `false`，开启此功能要通过命令 `npm i --save hexo-wordcount` 安装 `wordcount` 插件。

我的博客已实现：www.itrhx.com

预览图：![wordcount](https://i.loli.net/2019/11/30/epyThGnXF1x9CW3.png)

