### PR TITLE
Restore white_text config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -431,11 +431,13 @@ plugins:
     shuffle: true         # shuffle playlist
     duration: 20000       # Duration (ms)
     fade: 1500            # fade duration (ms) (Not more than 1500)
+    white_text: #true     # Whether the picture is dark (adjust the text to white)
     images:               # For personal use only. At your own risk if used for commercial purposes !!!
       - https://cdn.jsdelivr.net/gh/xaoxuu/cdn-wallpaper/abstract/41F215B9-261F-48B4-80B5-4E86E165259E.jpeg
       # - https://cdn.jsdelivr.net/gh/xaoxuu/cdn-wallpaper/abstract/BBC19066-E176-47C2-9D22-48C81EE5DF6B.jpeg
       # - https://cdn.jsdelivr.net/gh/xaoxuu/cdn-wallpaper/abstract/B18FCBB3-67FD-48CC-B4F3-457BA145F17A.jpeg
       # - https://cdn.jsdelivr.net/gh/xaoxuu/cdn-wallpaper/abstract/00E0F0ED-9F1C-407A-9AA6-545649D919F4.jpeg
+      # # Suggest white_text: true
       # - https://cdn.jsdelivr.net/gh/xaoxuu/cdn-wallpaper/abstract/67239FBB-E15D-4F4F-8EE8-0F1C9F3C4E7C.jpeg
       # - https://cdn.jsdelivr.net/gh/xaoxuu/cdn-wallpaper/abstract/B951AE18-D431-417F-B3FE-A382403FF21B.jpeg
       # - https://cdn.jsdelivr.net/gh/xaoxuu/cdn-wallpaper/landscape/AEB33F9D-7294-4CF1-B8C5-3020748A9D45.jpeg

--- a/layout/_cover/index.ejs
+++ b/layout/_cover/index.ejs
@@ -4,10 +4,10 @@
       <img class='logo' src='<%- url_for(theme.cover.logo) %>'/>
     <% } %>
     <% if (theme.cover.title) { %>
-      <p class="title"><%- theme.cover.title ? theme.cover.title : config.title %></p>
+      <p class="title <%- theme.plugins.backstretch && theme.plugins.backstretch.white_text ? 'white' : '' %>"><%- theme.cover.title ? theme.cover.title : config.title %></p>
     <% } %>
     <% if (theme.cover.subtitle) { %>
-      <p class="subtitle"><%- theme.cover.subtitle%></p>
+      <p class="subtitle <%- theme.plugins.backstretch && theme.plugins.backstretch.white_text ? 'white' : '' %>"><%- theme.cover.subtitle%></p>
     <% } %>
   </div>
   <div class='b'>

--- a/layout/_cover/index.ejs
+++ b/layout/_cover/index.ejs
@@ -24,7 +24,7 @@
         <% if (theme.cover.features) { %>
           <% (theme.cover.features || []).forEach(function(value){ %>
             <li>
-              <a class="nav home"
+              <a class="nav home <%- theme.plugins.backstretch && theme.plugins.backstretch.white_text ? 'white' : '' %>"
                 href="<%= url_for(value.url) %>"
                 <% if (value.rel) { %>
                   rel="<%- value.rel %>"

--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -5,7 +5,7 @@
     layout = config.theme_config.footer.layout;
   }
   %>
-  <footer class="clearfix">
+  <footer class="clearfix <%- theme.plugins.backstretch && theme.plugins.backstretch.white_text ? 'white' : '' %>">
     <br><br>
     <% layout.forEach(function(item){ %>
       <% if (item == 'social') { %>


### PR DESCRIPTION
将[2.1.5](https://github.com/xaoxuu/hexo-theme-volantis/tree/2.1.5)中删除的`white_text`选项加回来...qwq

位于[config.yml2.1.5版本第433行后](https://github.com/xaoxuu/hexo-theme-volantis/compare/2.1.4...master#diff-aeb42283af8ef8e9da40ededd3ae2ab2L432)，是不是因为优化css才删除的？

我的[博客](https://charlie-zzy.github.io/)是暗色主题，所以需要白色字体...