### PR TITLE
move the telegram logo link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -232,7 +232,7 @@ meta:
     # - id: qrcode # 当id为qrcode时需要安装插件  npm i -S hexo-helper-qrcode
     #   img: https://cdn.jsdelivr.net/gh/xaoxuu/cdn-assets/logo/128/wechat.png
     # - id: telegram
-    #   img: https://img.icons8.com/color/144/000000/telegram-app.png
+    #   img: https://cdn.jsdelivr.net/gh/xaoxuu/cdn-assets/logo/128/telegram.png
   # 链接
   btns:
     edit:


### PR DESCRIPTION
很抱歉再次打扰到您，把telegram logo链接换成你仓库的cdn地址，:smile:
看看这个commit：[1f320a8 ](https://github.com/xaoxuu/cdn-assets/commit/1f320a86f8621dd809417bb5940f9117264b2cc3)