### PR TITLE
代码块copy按钮完善

### DIFF
--- a/layout/_third-party/clipboard.ejs
+++ b/layout/_third-party/clipboard.ejs
@@ -4,12 +4,11 @@
     var timelag = null;
     timelag = window.setTimeout(callback, seconds);
   }
-  
   !function (e, t, a) {
     var initCopyCode = function(){
       var copyHtml = '';
       copyHtml += '<button class="btn-copy" data-clipboard-snippet="">';
-      copyHtml += '<i class="far fa-copy"></i><span>COPY</span>';
+      copyHtml += '<i class="fas fa-copy"></i><span>COPY</span>';
       copyHtml += '</button>';
       $(".highlight .code pre").before(copyHtml);
       $(".article pre code").before(copyHtml);

--- a/layout/_third-party/clipboard.ejs
+++ b/layout/_third-party/clipboard.ejs
@@ -1,10 +1,15 @@
 <script src="<%- theme.plugins.clipboard %>"></script>
 <script>
+  function wait(callback, seconds) {
+    var timelag = null;
+    timelag = window.setTimeout(callback, seconds);
+  }
+  
   !function (e, t, a) {
     var initCopyCode = function(){
       var copyHtml = '';
       copyHtml += '<button class="btn-copy" data-clipboard-snippet="">';
-      copyHtml += '<i class="fas fa-copy"></i><span>COPY</span>';
+      copyHtml += '<i class="far fa-copy"></i><span>COPY</span>';
       copyHtml += '</button>';
       $(".highlight .code pre").before(copyHtml);
       $(".article pre code").before(copyHtml);
@@ -18,9 +23,15 @@
         $btn.addClass('copied');
         let $icon = $($btn.find('i'));
         $icon.removeClass('fa-copy');
-        $icon.addClass('fa-clipboard-check');
+        $icon.addClass('fa-check-circle');
         let $span = $($btn.find('span'));
         $span[0].innerText = 'COPIED';
+        
+        wait(function () { // 等待两秒钟后恢复
+          $icon.removeClass('fa-check-circle');
+          $icon.addClass('fa-copy');
+          $span[0].innerText = 'COPY';
+        }, 2000);
       });
       clipboard.on('error', function(e) {
         e.clearSelection();
@@ -28,9 +39,15 @@
         $btn.addClass('copy-failed');
         let $icon = $($btn.find('i'));
         $icon.removeClass('fa-copy');
-        $icon.addClass('fa-exclamation-triangle');
+        $icon.addClass('fa-times-circle');
         let $span = $($btn.find('span'));
         $span[0].innerText = 'COPY FAILED';
+        
+        wait(function () { // 等待两秒钟后恢复
+          $icon.removeClass('fa-times-circle');
+          $icon.addClass('fa-copy');
+          $span[0].innerText = 'COPY';
+        }, 2000);
       });
     }
     initCopyCode();


### PR DESCRIPTION
1. 实现了按下`copy`按钮后显示`copied`或`copy failed`**两秒钟后恢复原状**
1. Font Awesome 图标优化(从Solid`fas-`变成Regular`far-`样式, 更加美观, 且仍为免费, 可以参看我的博客)