### PR TITLE
update vssue to 1.4.4, set prefix to empty and autoCreateIssue to true

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -100,7 +100,7 @@
   <% } %>
 
   <% if (theme.comments.vssue && theme.comments.vssue.clientId) { %>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/meteorlxy/vssue@1.4.3/packages/vssue/dist/vssue.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/meteorlxy/vssue@1.4.4/packages/vssue/dist/vssue.min.css">
   <% } %>
 
   <!-- import link -->

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -185,7 +185,7 @@
 <% } %>
 <% if (enableVssue) { %>
   <script src="https://cdn.jsdelivr.net/gh/vuejs/vue@2.6.11/dist/vue.runtime.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/gh/meteorlxy/vssue@1.4.3/packages/vssue/dist/vssue.github.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/meteorlxy/vssue@1.4.4/packages/vssue/dist/vssue.github.min.js"></script>
   <script>
     new Vue({
       el: '#vssue',
@@ -198,6 +198,8 @@
             repo: '<%- theme.comments.vssue.repo %>',
             clientId: '<%- theme.comments.vssue.clientId %>',
             clientSecret: '<%- theme.comments.vssue.clientSecret %>',
+            prefix: '',
+            autoCreateIssue: true,
           },
         }
       })


### PR DESCRIPTION
vssue 版本更新，将创建 issue 的前缀（[prefix](https://vssue.js.org/zh/options/#prefix)）置空，启用登录帐号后自动创建（[autoCreateIssue](https://vssue.js.org/zh/options/#autocreateissue)） issue（否则需要手动点击创建 issue）。