### PR TITLE
Pjax push

### DIFF
--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -436,6 +436,13 @@
 
     try{
       pjax_fancybox();
+      <% if (theme.plugins.backstretch && theme.plugins.backstretch.enable && theme.plugins.backstretch.images) { %>
+        if ('<%- posi %>') {
+          $('<%- posi %>').backstretch("resize");
+        } else {
+          $.backstretch("resize");
+        }
+      <% } %>
       <% if (theme.plugins.scrollreveal && theme.plugins.scrollreveal.js) { %>
         pjax_scrollrebeal();
       <% } %>


### PR DESCRIPTION
修复个小 bug ，复现场景：
-   backstretch 的 position 设置为 cover 时，从无封面跳转到有封面的页面后封面大小错误。