### PR TITLE
处理移动端评论和目录按钮

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -3,7 +3,7 @@
   <div class='wrapper'>
     <div class='nav-sub'>
       <p class="title"></p>
-      <ul class='switcher nav-list-h'>
+      <ul class='switcher nav-list-h' id="pjax-header-nav-list">
         <li><a class="s-comment fas fa-comments fa-fw" target="_self" href='javascript:void(0)'></a></li>
         <% if (page.sidebar == undefined || page.sidebar != false) { %>
           <li><a class="s-toc fas fa-list fa-fw" target="_self" href='javascript:void(0)'></a></li>

--- a/layout/_third-party/pjax/index.ejs
+++ b/layout/_third-party/pjax/index.ejs
@@ -22,7 +22,8 @@
         elements: 'a[href]:not([href^="#"]):not([href="javascript:void(0)"]):not([pjax-fancybox])',
         selectors: [
           "title",
-          "#pjax-container"
+          "#pjax-container",
+          "#pjax-header-nav-list"
         ],
         cacheBust: <%= theme.plugins.pjax.cacheBust %>,   // url 地址追加时间戳，用以避免浏览器缓存
         timeout: <%= theme.plugins.pjax.timeout %>
@@ -49,10 +50,8 @@
       $('.l_header').removeClass('z_search-open'); // 关闭移动端激活的搜索框
       $('.wrapper').removeClass('sub'); // 跳转页面时关闭二级导航
 
-      $('.s-top').unbind('click'); // 解绑
+      $('.s-top').unbind('click');   // 解绑
       $('.menu a').unbind('click');  // 解绑
-      $('.s-toc', $('header .wrapper')).unbind('click'); // 解绑
-      $('.s-comment', $('header .wrapper')).unbind('click'); // 解绑
       $(window).unbind('resize');    // 解绑
       $(window).unbind('scroll');    // 解绑
       $(document).unbind('scroll');  // 解绑

--- a/source/js/app.js
+++ b/source/js/app.js
@@ -119,8 +119,7 @@ var customSearch;
 		const $wrapper = $('header .wrapper');        // 整个导航栏
 		const $comment = $('.s-comment', $wrapper);   // 评论按钮  桌面端 移动端
 		const $toc = $('.s-toc', $wrapper);           // 目录按钮  仅移动端
-
-		$comment.show(); // 显示 (某些文章可能关闭了评论，故先行显示)
+		
 		$wrapper.find('.nav-sub .title').text(window.subData.title);   // 二级导航文章标题
 
 		// 决定一二级导航栏的切换
@@ -146,7 +145,7 @@ var customSearch;
 				scrolltoElement($('.l_body .comments'));
 				e.stopImmediatePropagation();
 			});
-		} else $comment.hide();   // 关闭了评论，则隐藏
+		} else $comment.remove(); // 关闭了评论，则隐藏
 
 		const $tocTarget = $('.l_body .toc-wrapper');     // 侧边栏的目录列表  PC
 		if ($tocTarget.length && $tocTarget.children().length) {


### PR DESCRIPTION
- 移动端：从无目录的文章跳转到有目录的文章也没后，导航栏目录按钮被移除了，没有再次显示出来。
- 把导航栏上这两个按钮加到了重载区域内，这样也就不用对它做过多的处理了（解绑事件，单篇文章的评论关闭等等。