### PR TITLE
使文章标题必须为其他语言时Gitalk不会报错标签过长

### DIFF
--- a/layout/_third-party/comments/gitalk/script.ejs
+++ b/layout/_third-party/comments/gitalk/script.ejs
@@ -10,7 +10,7 @@
     <% if(page.gitalk && page.gitalk.id) { %>
       id: "<%= page.gitalk.id %>",
     <% } else { %>
-      id: location.pathname,      // Ensure uniqueness and length less than 50
+      id: decodeURI(location.pathname),      // Ensure uniqueness and length less than 50
     <% } %>
     distractionFreeMode: false  // Facebook-like distraction free mode
   });


### PR DESCRIPTION
比方说`https://blog.lhkstudio.me/2020/07/05/yuque/算法笔记%20-%20哈希`这篇文章

它就会变成`https://blog.lhkstudio.me/2020/07/05/yuque/%E7%AE%97%E6%B3%95%E7%AC%94%E8%AE%B0%20-%20%E5%93%88%E5%B8%8C/`

Gitalk会建立相关标签为`/2020/07/05/yuque/%E7%AE%97%E6%B3%95%E7%AC%94%E8%AE%B0%20-%20%E5%93%88%E5%B8%8C/`超过了50个字符, 报错

用`decodeURI`解码后, Gitalk建立的标签为
`/2020/07/05/yuque/算法笔记 - 哈希/`

少于50个字符, 成功创建~ https://github.com/Linhk1606/blog-source/issues/17