### PR TITLE
完美添加右键菜单

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -163,22 +163,6 @@ navbar:
       url: about/
   search: Search...   # Search bar placeholder
   
-  # 右键菜单配置（需要启用 rightmenu）
-  rightmenu:
-    # 这个配置项也可以写在 `blog/source/_data/rightmenu.yml`
-    - name: 文档
-      icon: fas fa-book
-      url: /v3/getting-started/
-    - name: 帮助
-      icon: fas fa-question-circle
-      url: faqs/
-    - name: 示例
-      icon: fas fa-play-circle
-      url: /examples/
-    - name: 社区
-      icon: fas fa-fan fa-spin
-      url: /contributors/
-
 
 
 layout:
@@ -488,9 +472,6 @@ plugins:
   # npm i --save hexo-wordcount
   wordcount: #true
   
-  # 右键菜单开关
-  rightmenu: true
-
   ######## Plugins for ...
   # Button Ripple Effect
   nodewaves:
@@ -691,6 +672,52 @@ comments:
   hashover:
     src: https://example.com/(path/)comments.php
 
+# 自定义右键菜单
+rightmenu:
+  enable: true
+  layout: [copy, hr, backward, forward, refresh, hr, home, help, examples, contributors, more]
+  copy:
+    name: 复制
+    icon: fa fa-copy
+    id: menu-copy
+    onclick: menuCopy()
+  backward:
+    name: 返回
+    icon: fa fa-arrow-left
+    onclick: history.back()
+  forward:
+    name: 前进
+    icon: fa fa-arrow-right
+    onclick: history.forward()
+  refresh:
+    name: 刷新
+    icon: fa fa-redo
+    onclick: window.location.reload()
+  home:
+    name: 主页
+    icon: fa fa-home
+    url: /
+  # 自定义菜单的格式如下
+  help:
+    name: 帮助
+    icon: fa fa-question-circle
+    url: https://volantis.js.org/faqs/
+  examples:
+    name: 示例
+    icon: fa fa-play
+    url: https://volantis.js.org/examples/
+  contributors:
+    name: 社区
+    icon: fa fa-fan fa-spin
+    url: https://volantis.js.org/contributors/
+  more:
+    name: 更多
+    icon: fa fa-ellipsis-v
+    rows:
+      - name: 本站源码
+        url: https://github.com/volantis-x/volantis-docs/
+      - name: 主题源码
+        url: https://github.com/volantis-x/hexo-theme-volantis/
 
 
 ############################### Search ###############################

--- a/_config.yml
+++ b/_config.yml
@@ -153,6 +153,22 @@ navbar:
       icon: fas fa-info-circle
       url: about/
   search: Search...   # Search bar placeholder
+  
+  # 右键菜单配置（需要启用 rightmenu）
+  rightmenu:
+    # 这个配置项也可以写在 `blog/source/_data/rightmenu.yml`
+    - name: 文档
+      icon: fas fa-book
+      url: /v3/getting-started/
+    - name: 帮助
+      icon: fas fa-question-circle
+      url: faqs/
+    - name: 示例
+      icon: fas fa-play-circle
+      url: /examples/
+    - name: 社区
+      icon: fas fa-fan fa-spin
+      url: /contributors/
 
 
 
@@ -462,6 +478,9 @@ plugins:
 
   # npm i --save hexo-wordcount
   wordcount: #true
+  
+  # 右键菜单开关
+  rightmenu: true
 
   ######## Plugins for ...
   # Button Ripple Effect

--- a/layout/_partial/rightmenu.ejs
+++ b/layout/_partial/rightmenu.ejs
@@ -1,0 +1,187 @@
+<% if (theme.plugins.rightmenu) { %>
+    <div id="menu-div" style="display: none;position:fixed;z-index: 2000;">
+      <ul class="list-v" id="menu-content" style="display: block;width: 120px;">
+        <li>
+          <a class="flat-box waves-effect waves-block" style="display: none;" id="menu-copy" onclick="menuCopy()">
+            <i class="fa fa-copy fa-fw"></i> 复制
+          </a>
+        </li>
+        <li>
+          <a class="flat-box waves-effect waves-block" onclick="history.back()">
+            <i class="fa fa-arrow-left fa-fw"></i> 返回
+          </a>
+        </li> 
+        <li>
+          <a class="flat-box waves-effect waves-block" onclick="window.location.reload()">
+            <i class="fa fa-redo fa-fw"></i> 刷新
+          </a>
+        </li>
+        <hr>
+        <%
+          let menu_list;
+          if (site.data && site.data.rightmenu && site.data.rightmenu) {
+            menu_list = site.data.rightmenu;
+          } else {
+            menu_list = theme.navbar.rightmenu;
+          }
+          menu_list = menu_list || [];
+          %>
+          <% function menu(value, type) { %>
+            <% if (value.name == 'hr') { %>
+              <hr>
+            <% } else if (value.icon && value.icon.indexOf('fa-compact-disc') > -1 && value.url  == undefined && value.rows  == undefined) { %>
+              <% if (type == 'pc') { %>
+                <li>
+                  <a class="flat-box waves-effect waves-block">
+                    <i class='<%= value.icon %> fa-fw music'></i> <%- value.name %>
+                  </a>
+                  <ul class="list-v">
+                    <li>
+                      <div class="aplayer-container">
+                        <%- partial('../_third-party/aplayer', {post: null, where: 'footer'}) %>
+                      </div>
+                    </li>
+                  </ul>
+                <li>
+              <% } %>
+            <% } else if (value.name != undefined && value.url  == undefined && value.rows == undefined) { %>
+              <li class="flat-box waves-effect waves-block">
+                <% if (value.icon) { %><i class='<%= value.icon %> fa-fw'></i><% } %> <%- value.name %>
+              </li>
+            <% } else { %>
+              <li>
+                <a class="flat-box waves-effect waves-block" <%= value.url ? 'href='+ url_for(value.url)+'' : ''%>
+                  <% if (value.rel) { %>
+                    rel="<%- value.rel %>"
+                  <% } %>
+                  <% if (value.target) { %>
+                    target="<%- value.target %>"
+                  <% } %>
+                  <% if (value.url) { %>
+                    id="<%= url_for(value.url).replace(/\/|%|\./g, "")?url_for(value.url).replace(/\/|%|\./g, ""):"home" %>"
+                  <% } %>>
+                  <% if (value.icon) { %><i class='<%= value.icon %> fa-fw'></i><% } %> <%- value.name %>
+                </a>
+                <% if (value.rows) { %>
+                  <ul class="list-v">
+                    <% value.rows.forEach(function(value){ %>
+                      <% menu(value, type) %>
+                    <%})%>
+                  </ul>
+                <% } %>
+              </li>
+            <% } %>
+          <% } %>
+          <% menu_list.forEach(function(value){ %>
+            <% menu(value, 'pc') %>
+          <% }) %>
+        <% if (theme.plugins.aplayer.enable) { %>
+        <hr>
+        <li>
+          <a class="flat-box">
+            <i class='fa fa-music fa-fw'></i> 音乐
+          </a>
+          <ul class="list-v" id="menu-showMusciCard">
+            <li>
+              <a class="flat-box waves-effect" onclick="menuPlay()">
+                <i class="fa fa-play fa-fw"></i> 播放
+              </a>
+            </li>
+            <li>
+              <a class="flat-box waves-effect" onclick="menuPause()">
+                <i class="fa fa-pause fa-fw"></i> 暂停
+              </a>
+            </li>
+            <li>
+              <a class="flat-box waves-effect" onclick="menuBackward()">
+                <i class="fa fa-angle-double-left fa-fw"></i> 上一首
+              </a>
+            </li>
+            <li>
+              <a class="flat-box waves-effect" onclick="menuForward()">
+                <i class="fa fa-angle-double-right fa-fw"></i> 下一首
+              </a>
+            </li>
+          </ul>
+        <li>
+        <% } %>
+      </ul>
+    </div>
+    
+    <script>
+      window.document.oncontextmenu = function () {
+        return false;
+      };
+      document.addEventListener("click", function (event) {
+        var mymenu = document.getElementById('menu-div');
+        mymenu.style.display = "none";
+      });
+      function popMenu(event) {
+        var copy = document.getElementById('menu-copy');
+        var select = window.getSelection().toString(); // 鼠标选中的文本
+        copy.style.display = select == "" ? "none" : "block";
+        var mymenu = document.getElementById('menu-div');
+        var menuContent = document.getElementById('menu-content');
+        var menuMusicCard = document.getElementById('menu-showMusciCard');
+        var mouseClientX = event.clientX;
+        var mouseClientY = event.clientY;
+        var menuWidth = menuContent.offsetWidth == 0 ? 120 : menuContent.offsetWidth;
+        var menuHeight = menuContent.offsetHeight == 0 ? 242 : menuContent.offsetHeight;
+        var screenWidth = document.documentElement.clientWidth || document.body.clientWidth;
+        var screenHeight = document.documentElement.clientHeight || document.body.clientHeight;
+        var showLeft = mouseClientX + menuWidth > screenWidth ? mouseClientX - menuWidth + 10 : mouseClientX;
+        var showTop = mouseClientY + menuHeight > screenHeight ? mouseClientY - menuHeight + 10 : mouseClientY;
+        mymenu.style.left = showLeft + "px"; // 获取鼠标位置
+        mymenu.style.top = showTop + "px";
+        mymenu.style.display = 'block';
+        // 音乐控制弹出层位置
+        if (mouseClientY + menuHeight  + 100 > screenHeight) {
+          menuMusicCard.style.marginTop = '-150px';
+        } else {
+          menuMusicCard.style.marginTop = '';
+        }
+        if (mouseClientX + menuWidth  + 110 > screenWidth) {
+          menuMusicCard.style.marginLeft = '-100px';
+        } else {
+          menuMusicCard.style.marginLeft = '110px';
+        }
+        return false; // 该行代码确保系统自带的右键菜单不会被调出
+      }
+      function hideMenu() {
+        document.getElementById('menu-div').style.display = 'none';
+      }
+      // 此处无需处理 js 加载异常
+      function menuPlay() {
+        var canplay = getCookie('canplay');
+        if( canplay == null || canplay == 'true') {
+          document.querySelector('meting-js').aplayer.play();
+        }
+      }
+      function menuPause() {
+        var canplay = getCookie('canplay');
+        if( canplay == null || canplay == 'true') {
+          document.querySelector('meting-js').aplayer.pause();
+          var index = document.querySelector('meting-js').aplayer.list.index;
+          var title = document.querySelector('meting-js').aplayer.list.audios[index].title;
+          var artist = document.querySelector('meting-js').aplayer.list.audios[index].artist;
+        }
+      }
+      function menuBackward() {
+        var canplay = getCookie('canplay');
+        if( canplay == null || canplay == 'true') {
+          document.querySelector('meting-js').aplayer.skipBack();
+          document.querySelector('meting-js').aplayer.play();
+        }
+      }
+      function menuForward() {
+        var canplay = getCookie('canplay');
+        if( canplay == null || canplay == 'true') {
+          document.querySelector('meting-js').aplayer.skipForward();
+          document.querySelector('meting-js').aplayer.play();
+        }
+      }
+      function menuCopy() {
+        document.execCommand("Copy"); 
+      }
+    </script>
+<% } %>

--- a/layout/_partial/rightmenu.ejs
+++ b/layout/_partial/rightmenu.ejs
@@ -1,187 +1,88 @@
-<% if (theme.plugins.rightmenu) { %>
-    <div id="menu-div" style="display: none;position:fixed;z-index: 2000;">
-      <ul class="list-v" id="menu-content" style="display: block;width: 120px;">
-        <li>
-          <a class="flat-box waves-effect waves-block" style="display: none;" id="menu-copy" onclick="menuCopy()">
-            <i class="fa fa-copy fa-fw"></i> 复制
-          </a>
-        </li>
-        <li>
-          <a class="flat-box waves-effect waves-block" onclick="history.back()">
-            <i class="fa fa-arrow-left fa-fw"></i> 返回
-          </a>
-        </li> 
-        <li>
-          <a class="flat-box waves-effect waves-block" onclick="window.location.reload()">
-            <i class="fa fa-redo fa-fw"></i> 刷新
-          </a>
-        </li>
-        <hr>
-        <%
-          let menu_list;
-          if (site.data && site.data.rightmenu && site.data.rightmenu) {
-            menu_list = site.data.rightmenu;
-          } else {
-            menu_list = theme.navbar.rightmenu;
-          }
-          menu_list = menu_list || [];
-          %>
-          <% function menu(value, type) { %>
-            <% if (value.name == 'hr') { %>
-              <hr>
-            <% } else if (value.icon && value.icon.indexOf('fa-compact-disc') > -1 && value.url  == undefined && value.rows  == undefined) { %>
-              <% if (type == 'pc') { %>
-                <li>
-                  <a class="flat-box waves-effect waves-block">
-                    <i class='<%= value.icon %> fa-fw music'></i> <%- value.name %>
-                  </a>
-                  <ul class="list-v">
-                    <li>
-                      <div class="aplayer-container">
-                        <%- partial('../_third-party/aplayer', {post: null, where: 'footer'}) %>
-                      </div>
-                    </li>
-                  </ul>
-                <li>
-              <% } %>
-            <% } else if (value.name != undefined && value.url  == undefined && value.rows == undefined) { %>
-              <li class="flat-box waves-effect waves-block">
-                <% if (value.icon) { %><i class='<%= value.icon %> fa-fw'></i><% } %> <%- value.name %>
-              </li>
-            <% } else { %>
-              <li>
-                <a class="flat-box waves-effect waves-block" <%= value.url ? 'href='+ url_for(value.url)+'' : ''%>
-                  <% if (value.rel) { %>
-                    rel="<%- value.rel %>"
-                  <% } %>
-                  <% if (value.target) { %>
-                    target="<%- value.target %>"
-                  <% } %>
-                  <% if (value.url) { %>
-                    id="<%= url_for(value.url).replace(/\/|%|\./g, "")?url_for(value.url).replace(/\/|%|\./g, ""):"home" %>"
-                  <% } %>>
-                  <% if (value.icon) { %><i class='<%= value.icon %> fa-fw'></i><% } %> <%- value.name %>
-                </a>
-                <% if (value.rows) { %>
-                  <ul class="list-v">
-                    <% value.rows.forEach(function(value){ %>
-                      <% menu(value, type) %>
-                    <%})%>
-                  </ul>
-                <% } %>
-              </li>
-            <% } %>
-          <% } %>
-          <% menu_list.forEach(function(value){ %>
-            <% menu(value, 'pc') %>
-          <% }) %>
-        <% if (theme.plugins.aplayer.enable) { %>
-        <hr>
-        <li>
-          <a class="flat-box">
-            <i class='fa fa-music fa-fw'></i> 音乐
-          </a>
-          <ul class="list-v" id="menu-showMusciCard">
-            <li>
-              <a class="flat-box waves-effect" onclick="menuPlay()">
-                <i class="fa fa-play fa-fw"></i> 播放
-              </a>
-            </li>
-            <li>
-              <a class="flat-box waves-effect" onclick="menuPause()">
-                <i class="fa fa-pause fa-fw"></i> 暂停
-              </a>
-            </li>
-            <li>
-              <a class="flat-box waves-effect" onclick="menuBackward()">
-                <i class="fa fa-angle-double-left fa-fw"></i> 上一首
-              </a>
-            </li>
-            <li>
-              <a class="flat-box waves-effect" onclick="menuForward()">
-                <i class="fa fa-angle-double-right fa-fw"></i> 下一首
-              </a>
-            </li>
-          </ul>
-        <li>
+<% if (theme.rightmenu && theme.rightmenu.enable == true && theme.rightmenu.layout.length > 0) { %>
+  <% function loadmenu(obj) { %>
+    <li>
+      <a class="vlts-menu" <%= obj.url ? 'href='+ url_for(obj.url)+'' : ''%>
+        <% if (obj.rel) { %>
+          rel="<%- obj.rel %>"
         <% } %>
-      </ul>
-    </div>
-    
-    <script>
-      window.document.oncontextmenu = function () {
-        return false;
-      };
-      document.addEventListener("click", function (event) {
-        var mymenu = document.getElementById('menu-div');
-        mymenu.style.display = "none";
-      });
-      function popMenu(event) {
-        var copy = document.getElementById('menu-copy');
-        var select = window.getSelection().toString(); // 鼠标选中的文本
-        copy.style.display = select == "" ? "none" : "block";
-        var mymenu = document.getElementById('menu-div');
-        var menuContent = document.getElementById('menu-content');
-        var menuMusicCard = document.getElementById('menu-showMusciCard');
-        var mouseClientX = event.clientX;
-        var mouseClientY = event.clientY;
-        var menuWidth = menuContent.offsetWidth == 0 ? 120 : menuContent.offsetWidth;
-        var menuHeight = menuContent.offsetHeight == 0 ? 242 : menuContent.offsetHeight;
-        var screenWidth = document.documentElement.clientWidth || document.body.clientWidth;
-        var screenHeight = document.documentElement.clientHeight || document.body.clientHeight;
-        var showLeft = mouseClientX + menuWidth > screenWidth ? mouseClientX - menuWidth + 10 : mouseClientX;
-        var showTop = mouseClientY + menuHeight > screenHeight ? mouseClientY - menuHeight + 10 : mouseClientY;
-        mymenu.style.left = showLeft + "px"; // 获取鼠标位置
-        mymenu.style.top = showTop + "px";
-        mymenu.style.display = 'block';
-        // 音乐控制弹出层位置
-        if (mouseClientY + menuHeight  + 100 > screenHeight) {
-          menuMusicCard.style.marginTop = '-150px';
-        } else {
-          menuMusicCard.style.marginTop = '';
-        }
-        if (mouseClientX + menuWidth  + 110 > screenWidth) {
-          menuMusicCard.style.marginLeft = '-100px';
-        } else {
-          menuMusicCard.style.marginLeft = '110px';
-        }
-        return false; // 该行代码确保系统自带的右键菜单不会被调出
+        <% if (obj.target) { %>
+          target="<%- obj.target %>"
+        <% } %>
+        <% if (obj.onclick) { %>
+          onclick="<%- obj.onclick %>"
+        <% } %>
+        <% if (obj.id) { %>
+          id="<%- obj.id %>"
+        <% } else if (obj.url) { %>
+          id="<%= url_for(obj.url).replace(/\/|%|\./g, "")?url_for(obj.url).replace(/\/|%|\./g, ""):"home" %>"
+        <% } %>>
+        <% if (obj.icon) { %><i class='<%= obj.icon %> fa-fw'></i><% } %> <%- obj.name %>
+      </a>
+      <% if (obj.rows) { %>
+        <ul class="list-v" id="rightmenu-submenu">
+          <% obj.rows.forEach(function(row){ %>
+            <% loadmenu(row) %>
+          <%})%>
+        </ul>
+      <% } %>
+    </li>
+  <% } %>
+
+  <div id="rightmenu-wrapper" style="display: none;position:fixed;z-index: 2000;">
+    <ul class="rightmenu list-v" id="rightmenu-content" style="display: block;width: 120px;">
+      <% theme.rightmenu.layout.forEach(function(item){ %>
+        <% if (item == 'hr') { %>
+          <hr>
+        <% } else if (item in theme.rightmenu) { %>
+          <% loadmenu(theme.rightmenu[item]) %>
+        <% } %>
+      <% }) %>
+    </ul>
+  </div>
+
+  <script>
+    window.document.oncontextmenu = function () {
+      return false;
+    };
+    document.addEventListener("click", function (event) {
+      var mymenu = document.getElementById('rightmenu-wrapper');
+      mymenu.style.display = "none";
+    });
+    function popMenu(event) {
+      var copy = document.getElementById('menu-copy');
+      var select = window.getSelection().toString(); // 鼠标选中的文本
+      copy.style.display = select == "" ? "none" : "block";
+      var mymenu = document.getElementById('rightmenu-wrapper');
+      var menuContent = document.getElementById('rightmenu-content');
+      var menuMusicCard = document.getElementById('rightmenu-submenu');
+      var mouseClientX = event.clientX;
+      var mouseClientY = event.clientY;
+      var menuWidth = menuContent.offsetWidth == 0 ? 120 : menuContent.offsetWidth;
+      var menuHeight = menuContent.offsetHeight == 0 ? 242 : menuContent.offsetHeight;
+      var screenWidth = document.documentElement.clientWidth || document.body.clientWidth;
+      var screenHeight = document.documentElement.clientHeight || document.body.clientHeight;
+      var showLeft = mouseClientX + menuWidth > screenWidth ? mouseClientX - menuWidth + 10 : mouseClientX;
+      var showTop = mouseClientY + menuHeight > screenHeight ? mouseClientY - menuHeight + 10 : mouseClientY;
+      mymenu.style.left = showLeft + "px"; // 获取鼠标位置
+      mymenu.style.top = showTop + "px";
+      mymenu.style.display = 'block';
+      if (mouseClientY + menuHeight  + 100 > screenHeight) {
+        menuMusicCard.style.marginTop = '-150px';
+      } else {
+        menuMusicCard.style.marginTop = '';
       }
-      function hideMenu() {
-        document.getElementById('menu-div').style.display = 'none';
+      if (mouseClientX + menuWidth  + 110 > screenWidth) {
+        menuMusicCard.style.marginLeft = '-100px';
+      } else {
+        menuMusicCard.style.marginLeft = '110px';
       }
-      // 此处无需处理 js 加载异常
-      function menuPlay() {
-        var canplay = getCookie('canplay');
-        if( canplay == null || canplay == 'true') {
-          document.querySelector('meting-js').aplayer.play();
-        }
-      }
-      function menuPause() {
-        var canplay = getCookie('canplay');
-        if( canplay == null || canplay == 'true') {
-          document.querySelector('meting-js').aplayer.pause();
-          var index = document.querySelector('meting-js').aplayer.list.index;
-          var title = document.querySelector('meting-js').aplayer.list.audios[index].title;
-          var artist = document.querySelector('meting-js').aplayer.list.audios[index].artist;
-        }
-      }
-      function menuBackward() {
-        var canplay = getCookie('canplay');
-        if( canplay == null || canplay == 'true') {
-          document.querySelector('meting-js').aplayer.skipBack();
-          document.querySelector('meting-js').aplayer.play();
-        }
-      }
-      function menuForward() {
-        var canplay = getCookie('canplay');
-        if( canplay == null || canplay == 'true') {
-          document.querySelector('meting-js').aplayer.skipForward();
-          document.querySelector('meting-js').aplayer.play();
-        }
-      }
-      function menuCopy() {
-        document.execCommand("Copy"); 
-      }
-    </script>
+      return false; // 该行代码确保系统自带的右键菜单不会被调出
+    }
+    function hideMenu() {
+      document.getElementById('menu-div').style.display = 'none';
+    }
+    function menuCopy() {
+      document.execCommand("Copy");
+    }
+  </script>
 <% } %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <%- partial('_partial/head') %>
-<% if (theme.plugins.rightmenu) { %>
+<% if (theme.rightmenu && theme.rightmenu.enable == true) { %>
 <body oncontextmenu="return popMenu(event);">
 <% } else { %>
 <body>
@@ -18,12 +18,16 @@
     <a class="s-top fas fa-arrow-up fa-fw" href='javascript:void(0)'></a>
   </div>
   <div>
-    <%- partial('_partial/rightmenu') %>
+    <% if (theme.rightmenu && theme.rightmenu.enable == true) { %>
+      <%- partial('_partial/rightmenu') %>
+    <% } %>
     <%- partial('_partial/scripts') %>
     <% if (theme.plugins.pjax.enable) { %>
       <%- partial('_third-party/pjax/index') %>
     <% } %>
   </div>
-  <script src="https://cdn.jsdelivr.net/gh/inkss/common@master/hexo/js/cookie.min.js"></script>
+  <% if (theme.rightmenu && theme.rightmenu.enable == true) { %>
+    <script src="https://cdn.jsdelivr.net/gh/inkss/common@master/hexo/js/cookie.min.js"></script>
+  <% } %>
 </body>
 </html>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 <html>
 <%- partial('_partial/head') %>
+<% if (theme.plugins.rightmenu) { %>
+<body oncontextmenu="return popMenu(event);">
+<% } else { %>
 <body>
+<% } %>
   <%- partial('_partial/cover') %>
   <div class="l_body<%- page.cover ? '' : ' nocover' %>">
     <div class='body-wrapper' id="pjax-container">
@@ -14,10 +18,12 @@
     <a class="s-top fas fa-arrow-up fa-fw" href='javascript:void(0)'></a>
   </div>
   <div>
+    <%- partial('_partial/rightmenu') %>
     <%- partial('_partial/scripts') %>
     <% if (theme.plugins.pjax.enable) { %>
       <%- partial('_third-party/pjax/index') %>
     <% } %>
   </div>
+  <script src="https://cdn.jsdelivr.net/gh/inkss/common@master/hexo/js/cookie.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
这个应该可以了吧

开启方法：
``` yml
plugins:
  rightmenu: true
```
配置方法（可在blog/source/_data/rightmenu.yml中配置）：
``` yml
navbar:
  rightmenu:
    - name: 首页
      icon: fas fa-home
      url: /
    ......
    - name: hr
    ......
```

说明：当plugins.aplayer未开启时，右键菜单不会出现最下面的音乐控制功能