### PR TITLE
评论系统相关的更新

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -581,6 +581,8 @@ plugins:
 
 ############################### Comments ###############################
 comments:
+  path:                    # 全局评论地址 仅支持 valine , miniValine , disqus , gitalk
+  placeholder: 快来评论吧~  # 评论占位提示 仅支持 valine & miniValine
   title: <i class='fas fa-comments'></i> 评论
   subtitle:
   service: valine # valine, minivaline, disqus, gitalk, vssue, livere, isso, hashover
@@ -590,11 +592,9 @@ comments:
     appId: # your appId
     appKey: # your appKey
     # js: https://cdn.jsdelivr.net/npm/valine@1.4/dist/Valine.min.js
-    path: # All pages use the same path (share the same comments data)
     meta: nick,mail,link # valine comment header info
     requiredFields: ['nick','mail']
     enableQQ: true # Unstable avatar link
-    placeholder: 快来评论吧~ # valine comment input placeholder(like: Please leave your footprints )
     avatar: robohash # gravatar style https://valine.js.org/avatar
     pageSize: 10 # comment list page size
     lang: zh-cn
@@ -608,8 +608,6 @@ comments:
     appKey: # your appKey
     js: https://cdn.jsdelivr.net/npm/minivaline@3/dist/MiniValine.min.js
     mode: xCss # DesertsP or xCss
-    placeholder: 快来评论吧~ # Comment box placeholder
-    path: # All pages use the same path (share the same comments data)
     math: false # Support MathJax.
     md: true # Support Markdown.
     enableQQ: false # Enable QQ avatar API.

--- a/layout/_partial/scripts.ejs
+++ b/layout/_partial/scripts.ejs
@@ -1,5 +1,4 @@
 <%- js('https://cdn.jsdelivr.net/npm/jquery@3.5/dist/jquery.min.js') %>
-<script>let CommentsSetting = new Object();</script>
 
 <% if (theme.search && theme.search.enable) { %>
   <script>

--- a/layout/_third-party/comments/disqus/layout.ejs
+++ b/layout/_third-party/comments/disqus/layout.ejs
@@ -1,5 +1,5 @@
 <div id="disqus_thread">
-  <div id="notShowDisqus" style="display: none;"><i class='fas fa-exclamation-triangle'></i>&nbsp;<%- __('post.comments_placeholder', 'Disqus') %></div>
-  <div id="load-btns"><a class="load-comments" onclick="enableDisqus()"><%- __('post.comments_load', 'Disqus') %></a></div>
-  <div id="loading-comments" style="display: none"><i class="fa fa-cog fa-spin fa-fw fa-2x"></i></div>
+  <div id="notShowDisqus" style="display: none;text-align: center;"><i class='fas fa-exclamation-triangle'></i>&nbsp;<%- __('post.comments_placeholder', 'Disqus') %></div>
+  <div id="load-btns"><a class="load-comments" onclick="enableDisqus()"><%- __('post.comments_load', 'Disqus') %></div>
+  <div id="loading-comments" style="display: none"><i class="fa fa-cog fa-spin fa-fw fa-2x"></i><br>正在检查 Disqus 能否访问...</a></div>
 </div>

--- a/layout/_third-party/comments/disqus/script.ejs
+++ b/layout/_third-party/comments/disqus/script.ejs
@@ -1,56 +1,87 @@
 <script>
-  var disqus_shortname = '<%= theme.comments.disqus.shortname %>';
-  var disqus_script = 'embed.js';
+  const disqus_shortname = '<%= theme.comments.disqus.shortname %>';
 
   function checkDisqus() {
-    setTimeout(() => {
-      if (document.getElementById('notShowDisqus') == null) {return;}
-      if (window.DISQUS == undefined) {
-        document.getElementById('notShowDisqus').style.display = 'block';
-        document.getElementById('load-btns').style.display = "block";
-      } else {
-        document.getElementById('notShowDisqus').style.display = 'none';
-        document.getElementById('load-btns').style.display = "none";
-      }
-      document.getElementById('loading-comments').style.display = "none";
-    }, 3000);
-  }
-  function enableDisqus() {
-    CommentsSetting.loadDisqus = true;
-    pjax_disqus();
-  }
-  function pjax_disqus() {
-    if (CommentsSetting.loadDisqus == undefined || CommentsSetting.loadDisqus == false) {
-      return;
-    }
-    if (document.getElementById('notShowDisqus') == null) {return;}
-
-    document.getElementById('loading-comments').style.display = "block";
-    document.getElementById('load-btns').style.display = "none";
-    try {
-      if (!window.DISQUS) {
-        (function(d,s) {
-        s = d.createElement('script');s.async=1;s.src = '//' + disqus_shortname + '.disqus.com/'+disqus_script;
-        try {
-          (d.getElementsByTagName('head')[0]).appendChild(s);
-        } catch (error) {
-          document.getElementById('notShowDisqus').style.display = 'block';
-        }
-        })(document);
-      } else {
-        DISQUS.reset({
-          reload: true,
-          config: function () {
-            this.page.identifier = decodeURI(location.pathname),
-            this.page.url = $.trim($('#pjax-permalink').text())
-          }
+    // 正在检查 Disqus 能否访问...
+    const runcheck = (domain) => {
+        return new Promise((resolve, reject) => {
+            const img = new Image;
+            const timeout = setTimeout(() => {
+                img.onerror = img.onload = null;
+                reject();
+            }, 3000);
+            img.onerror = () => {
+                clearTimeout(timeout);
+                reject();
+            }
+            img.onload = () => {
+                clearTimeout(timeout);
+                resolve();
+            }
+            img.src = `https://${domain}/favicon.ico?${+(new Date)}=${+(new Date)}`;
         })
-      }
-    } catch (error) {
-      document.getElementById('notShowDisqus').style.display = 'block';
     }
-    checkDisqus();
+    return Promise.all([
+        runcheck('disqus.com'),
+        runcheck('<%= theme.comments.disqus.shortname %>.disqus.com')
+    ]).then(useDisqus,showError);
   }
 
-  // pjax_disqus();
+  function loadDisqus() {
+    let pageUrl = $.trim($('#pjax-comment-path').text()) === "none" ? 
+      decodeURI(window.location.pathname) : $.trim($('#pjax-comment-path').text());
+    
+    let ALLPATH = '<%= theme.comments.path %>';
+    if(ALLPATH != '') pageUrl = ALLPATH;
+
+    if (window.DISQUS) {
+      window.DISQUS.reset({
+          reload: true,
+          config() {
+            this.page.identifier = pageUrl;
+            this.page.url = pageUrl;
+          }
+      });
+    } else {
+        window.disqus_config = function () {
+          this.page.url = pageUrl;
+          this.page.identifier = pageUrl;
+        };
+        let d = document, s = d.createElement('script');
+        s.async = true;
+        s.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
+    }
+  }
+
+  function useDisqus() {
+      console.log('Disqus 评论系统开始加载');
+      loadDisqus();
+  }
+
+  function showError() {
+    window.FileLoadDisqus = true;
+    $('#loading-comments').hide();
+    $('#notShowDisqus').show();
+  }
+
+  function enableDisqus() {
+    checkDisqus();
+    $('#load-btns').hide();
+    $('#loading-comments').show();
+  }
+
+  function pjax_disqus() {
+    if (window.DISQUS) {
+      $('#load-btns').hide();
+      $('#notShowDisqus').hide();
+      $('#loading-comments').hide();
+      loadDisqus();
+    } else if(window.FileLoadDisqus) {
+      $('#load-btns').hide();
+      $('#notShowDisqus').show();
+      $('#loading-comments').hide();
+    }
+  }
 </script>

--- a/layout/_third-party/comments/gitalk/script.ejs
+++ b/layout/_third-party/comments/gitalk/script.ejs
@@ -1,7 +1,12 @@
 <script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
 <script type="text/javascript">
   function pjax_gitalk() {
-    console.log(document.getElementById('gitalk-container'));
+    let pageUrl = $.trim($('#pjax-comment-path').text()) === "none" ? 
+      decodeURI(window.location.pathname) : $.trim($('#pjax-comment-path').text());
+    
+    let ALLPATH = '<%= theme.comments.path %>';
+    if(ALLPATH != '') pageUrl = ALLPATH;
+
     if (document.getElementById('gitalk-container') != null) {
       var gitalk = new Gitalk({
         clientID: "<%- theme.comments.gitalk.clientID %>",
@@ -9,11 +14,7 @@
         repo: "<%- theme.comments.gitalk.repo %>",
         owner: "<%- theme.comments.gitalk.owner %>",
         admin: "<%- theme.comments.gitalk.admin %>",
-        <% if(page.gitalk && page.gitalk.id) { %>
-          id: "<%= page.gitalk.id %>",
-        <% } else { %>
-          id: decodeURI(location.pathname),      // Ensure uniqueness and length less than 50
-        <% } %>
+        id: pageUrl,
         distractionFreeMode: false  // Facebook-like distraction free mode
       });
       gitalk.render('gitalk-container');

--- a/layout/_third-party/comments/index.ejs
+++ b/layout/_third-party/comments/index.ejs
@@ -1,4 +1,10 @@
-<% if (page.comments && theme.comments.service && theme.comments.service.length > 0) { %>
+<%
+    var checkComment = true;
+    if (page.comment && page.comment.enable == false) {
+      checkComment = false;
+    }
+%>
+<% if (checkComment && theme.comments.service && theme.comments.service.length > 0) { %>
   <article class="post white-box reveal comments <%- theme.style.body.effect.join(' ') %>">
     <section class="article typo">
       <p ct><%- theme.comments && theme.comments.title %></p>

--- a/layout/_third-party/comments/minivaline/script.ejs
+++ b/layout/_third-party/comments/minivaline/script.ejs
@@ -9,41 +9,43 @@
 <% var friends = theme.comments.minivaline.friends  || []  %>
 <script>
 function pjax_minivaline() {
-  var minivalinePath = $.trim($('#minivaline-path').text()) === "none" ?
-      window.location.pathname : $.trim($('#minivaline-path').text());
-  var minivalinePlaceholder = $.trim($('#minivaline-placeholder').text()) === "none" ?
-      "<%= theme.comments.minivaline.placeholder %>" : $.trim($('#minivaline-placeholder').text());
-  var ALLPATH = '<%= theme.comments.minivaline.path %>';
-  if(ALLPATH != '') minivalinePath = ALLPATH;
-new MiniValine({
-  el: '#minivaline_container',
-  appId: '<%= theme.comments.minivaline.appId %>',
-  appKey: '<%= theme.comments.minivaline.appKey %>',
-  mode: '<%= theme.comments.minivaline.mode %>',
-  placeholder: minivalinePlaceholder,
-  pathname: minivalinePath,
-  lang: '<%= theme.comments.minivaline.lang %>',
-  adminEmailMd5: '<%= theme.comments.minivaline.adminEmailMd5 %>',
-  tagMeta: <%- '["' + tagMeta.join('", "') + '"]' %>,
-  master: <%- '["' + master.join('", "') + '"]' %>,
-  friends: <%- '["' + friends.join('", "') + '"]' %>,
-  math: <%= theme.comments.minivaline.math %>,  /*布尔值 字符串无效 下同*/
-  md: <%= theme.comments.minivaline.md %>,
-  enableQQ: <%= theme.comments.minivaline.enableQQ %>,
-  NoRecordIP: <%= theme.comments.minivaline.NoRecordIP %>,
-  visitor: <%= theme.comments.minivaline.visitor %>,
-  maxNest: <%= theme.comments.minivaline.maxNest %>,
-  pageSize: <%= theme.comments.minivaline.pageSize %>,
-  barrager: <%= theme.comments.minivaline.barrager %>,
-  role: '<%= theme.comments.minivaline.role %>',
-  closeFlag: <%= theme.comments.minivaline.closeFlag %>,
-  cloudflag: <%= theme.comments.minivaline.cloudflag %>,
-  region: <%= theme.comments.minivaline.region %>,
-  closeUA: <%= theme.comments.minivaline.closeUA %>,
-  emoticonUrl: <%- '["' + emoticonUrl.join('", "') + '"]' %>,
-  serverURLs: '<%= theme.comments.minivaline.serverURLs %>'
-  });
-}
+  let pageUrl = $.trim($('#pjax-comment-path').text()) === "none" ? 
+      decodeURI(window.location.pathname) : $.trim($('#pjax-comment-path').text());
+  let pagePlaceholder = $.trim($('#pjax-comment-placeholder').text()) === "none" ?
+    "<%= theme.comments.placeholder %>" : $.trim($('#"pjax-comment-placeholder').text());
+
+  let ALLPATH = '<%= theme.comments.path %>';
+  if(ALLPATH != '') pageUrl = ALLPATH;
+
+  new MiniValine({
+    el: '#minivaline_container',
+    appId: '<%= theme.comments.minivaline.appId %>',
+    appKey: '<%= theme.comments.minivaline.appKey %>',
+    mode: '<%= theme.comments.minivaline.mode %>',
+    placeholder: pagePlaceholder,
+    path: pageUrl,
+    lang: '<%= theme.comments.minivaline.lang %>',
+    adminEmailMd5: '<%= theme.comments.minivaline.adminEmailMd5 %>',
+    tagMeta: <%- '["' + tagMeta.join('", "') + '"]' %>,
+    master: <%- '["' + master.join('", "') + '"]' %>,
+    friends: <%- '["' + friends.join('", "') + '"]' %>,
+    math: <%= theme.comments.minivaline.math %>,  /*布尔值 字符串无效 下同*/
+    md: <%= theme.comments.minivaline.md %>,
+    enableQQ: <%= theme.comments.minivaline.enableQQ %>,
+    NoRecordIP: <%= theme.comments.minivaline.NoRecordIP %>,
+    visitor: <%= theme.comments.minivaline.visitor %>,
+    maxNest: <%= theme.comments.minivaline.maxNest %>,
+    pageSize: <%= theme.comments.minivaline.pageSize %>,
+    barrager: <%= theme.comments.minivaline.barrager %>,
+    role: '<%= theme.comments.minivaline.role %>',
+    closeFlag: <%= theme.comments.minivaline.closeFlag %>,
+    cloudflag: <%= theme.comments.minivaline.cloudflag %>,
+    region: <%= theme.comments.minivaline.region %>,
+    closeUA: <%= theme.comments.minivaline.closeUA %>,
+    emoticonUrl: <%- '["' + emoticonUrl.join('", "') + '"]' %>,
+    serverURLs: '<%= theme.comments.minivaline.serverURLs %>'
+    });
+  }
   $(function () {
     pjax_minivaline();
   });

--- a/layout/_third-party/comments/valine/script.ejs
+++ b/layout/_third-party/comments/valine/script.ejs
@@ -35,21 +35,20 @@
   }
 
   function pjax_valine() {
-    var valinePath = $.trim($('#valine-path').text()) === "none" ?
-            window.location.pathname : $.trim($('#valine-path').text());
+    let pageUrl = $.trim($('#pjax-comment-path').text()) === "none" ? 
+      decodeURI(window.location.pathname) : $.trim($('#pjax-comment-path').text());
+    let pagePlaceholder = $.trim($('#pjax-comment-placeholder').text()) === "none" ?
+      "<%= theme.comments.placeholder %>" : $.trim($('#"pjax-comment-placeholder').text());
 
-    var valinePlaceholder = $.trim($('#valine-placeholder').text()) === "none" ?
-            "<%= theme.comments.valine.placeholder %>" : $.trim($('#valine-placeholder').text());
-
-    var ALLPATH = '<%= theme.comments.valine.path %>';
-    if(ALLPATH != '') valinePath = ALLPATH;
+    let ALLPATH = '<%= theme.comments.path %>';
+    if(ALLPATH != '') pageUrl = ALLPATH;
 
     var valine = new Valine();
     valine.init({
       el: '#valine_container',
       meta: meta,
-      placeholder: valinePlaceholder,
-      path: valinePath,
+      placeholder: pagePlaceholder,
+      path: pageUrl,
       appId: "<%= theme.comments.valine.appId %>",
       appKey: "<%= theme.comments.valine.appKey %>",
       pageSize: '<%= theme.comments.valine.pageSize %>',

--- a/layout/_third-party/pjax/data.ejs
+++ b/layout/_third-party/pjax/data.ejs
@@ -1,98 +1,80 @@
-<!--此文件用来存放一些不方便取值的变量-->
-<!--思路大概是将值藏到重加载的区域内-->
-
-<%
-var changeValinePath = 'none';                // 自定义的 valine 评论路径
-var changeValinePlaceholder = 'none';         // 自定义的 valine 评论描述 
-var changeMiniValinePath = 'none';            // 自定义的 Minivaline 评论路径
-var changeMiniValinePlaceholder = 'none';     // 自定义的 Minivaline 评论描述
-var ispage = false;                           // 一二级导航栏切换控制
-var postTitle = '';                           // 当前文章标题，用于二级导航栏赋值
-var enableCover = false;                      // 封面是否开启
-var frontMatterCover = 'none';                // 封面控制
-var permalink = page.permalink;               // 页面的完整网址
-
-var enableValine = false;
-if (theme.comments.service == 'valine') {
-  enableValine = true;
-}
-if (page && page.comments == true) {
-  if (enableValine && page.valine && page.valine.path) {
-    changeValinePath = page.valine.path;
-  }
-  if (enableValine && page.valine && page.valine.placeholder) {
-    changeValinePlaceholder = page.valine.placeholder;
-  }
-}
-
-var enableMiniValine = false;
-if (theme.comments.service == 'minivaline') {
-  enableMiniValine = true;
-}
-if (page && page.comments == true) {
-  if (enableMiniValine && page.valine && page.valine.path) {
-    changeMiniValinePath = page.valine.path;
-  }
-  if (enableMiniValine && page.valine && page.valine.placeholder) {
-    changeMiniValinePlaceholder = page.valine.placeholder;
-  }
-}
-
-if(theme.cover && theme.cover.scheme) {
-  enableCover = true;
-}
-
-if (enableCover && page && page.cover) {
-  frontMatterCover = page.cover;
-  if (is_home() && page.prev == 0 && theme.cover.scheme == 'docs') {
-    frontMatterCover = 'docs';
-  } else {
-    frontMatterCover = 'blog';
-  }
-}
-
-if (page && page.layout == 'post' && page.title) {
-  ispage = true;
-  postTitle = page.title;
-}
-
-%>
-
-<div id="pjax-data" style="display: none">
-  <div id="pjax-ispage"><%=ispage%></div>
-  <div id="pjax-pageTitle"><%=postTitle%></div>
-  <div id="pjax-enable-cover"><%=enableCover%></div>
-  <div id="pjax-permalink"><%=permalink%></div>
-  <% if (enableValine){ %>
-  <div id="valine-path"><%=changeValinePath%></div>
-  <div id="valine-placeholder"><%=changeValinePlaceholder%></div>
-  <% } %>
-  <% if (enableMiniValine){ %>
-  <div id="minivaline-path"><%=changeMiniValinePath%></div>
-  <div id="minivaline-placeholder"><%=changeMiniValinePlaceholder%></div>
-  <% } %>
-</div>
-
-<% if (enableCover) { %>
-<script>
-  // 处理封面 此时 jquery 还没加载
-  if ("<%=frontMatterCover%>" == "none") { // 移除封面
-    document.getElementsByClassName('cover')[0].style.display = "none";
-    document.getElementsByClassName('l_body')[0].classList.add("nocover");
-    document.getElementsByClassName('l_header', 'cover-wrapper')[0].classList.add("show");
-  } else {
-    if ("<%=frontMatterCover%>" == "blog") { // 半屏
-      document.getElementsByClassName('cover')[0].classList.remove("full");
-      document.getElementsByClassName('cover')[0].classList.add("half");
-      document.getElementsByClassName('scroll-down')[0].style.display = "none";
-    } else if ("<%=frontMatterCover%>" == "docs") { // 全屏
-      document.getElementsByClassName('cover')[0].classList.remove("half");
-      document.getElementsByClassName('cover')[0].classList.add("full");
-      document.getElementsByClassName('scroll-down')[0].style.display = "";
-    }
-    document.getElementsByClassName('cover')[0].style.display = "";
-    document.getElementsByClassName('l_body', 'show')[0].classList.remove("nocover");
-    document.getElementsByClassName('l_header', 'cover-wrapper')[0].classList.remove("show");
-  }
-</script>
+<!--此文件用来存放一些不方便取值的变量--> 
+<!--思路大概是将值藏到重加载的区域内--> 
+ 
+<% 
+var commentPath = 'none';                     // 自定义的评论路径 
+var commentPlaceholder = 'none';              // 自定义的评论描述 
+var ispage = false;                           // 一二级导航栏切换控制 
+var postTitle = '';                           // 当前文章标题，用于二级导航栏赋值 
+var enableCover = false;                      // 封面是否开启 
+var frontMatterCover = 'none';                // 封面控制 
+ 
+if (page && page.comments == true && page.comment) { 
+  if (page.comment.path) { 
+    commentPath = page.comment.path; 
+  } 
+  if (page.comment.placeholder) { 
+    commentPlaceholder = page.comment.placeholder; 
+  } 
+} 
+ 
+var enableValine = false; 
+if (theme.comments.service == 'valine') { 
+  enableValine = true; 
+} 
+var enableMiniValine = false; 
+if (theme.comments.service == 'minivaline') { 
+  enableMiniValine = true; 
+} 
+ 
+if(theme.cover && theme.cover.scheme) { 
+  enableCover = true; 
+} 
+ 
+if (enableCover && page && page.cover) { 
+  frontMatterCover = page.cover; 
+  if (is_home() && page.prev == 0 && theme.cover.scheme == 'docs') { 
+    frontMatterCover = 'docs'; 
+  } else { 
+    frontMatterCover = 'blog'; 
+  } 
+} 
+ 
+if (page && page.layout == 'post' && page.title) { 
+  ispage = true; 
+  postTitle = page.title; 
+} 
+ 
+%> 
+ 
+<div id="pjax-data" style="display: none"> 
+  <div id="pjax-ispage"><%=ispage%></div> 
+  <div id="pjax-pageTitle"><%=postTitle%></div> 
+  <div id="pjax-enable-cover"><%=enableCover%></div> 
+  <div id="pjax-comment-path"><%=commentPath%></div> 
+  <div id="pjax-comment-placeholder"><%=commentPlaceholder%></div> 
+</div> 
+ 
+<% if (enableCover) { %> 
+<script> 
+  // 处理封面 此时 jquery 还没加载 
+  if ("<%=frontMatterCover%>" == "none") { // 移除封面 
+    document.getElementsByClassName('cover')[0].style.display = "none"; 
+    document.getElementsByClassName('l_body')[0].classList.add("nocover"); 
+    document.getElementsByClassName('l_header', 'cover-wrapper')[0].classList.add("show"); 
+  } else { 
+    if ("<%=frontMatterCover%>" == "blog") { // 半屏 
+      document.getElementsByClassName('cover')[0].classList.remove("full"); 
+      document.getElementsByClassName('cover')[0].classList.add("half"); 
+      document.getElementsByClassName('scroll-down')[0].style.display = "none"; 
+    } else if ("<%=frontMatterCover%>" == "docs") { // 全屏 
+      document.getElementsByClassName('cover')[0].classList.remove("half"); 
+      document.getElementsByClassName('cover')[0].classList.add("full"); 
+      document.getElementsByClassName('scroll-down')[0].style.display = ""; 
+    } 
+    document.getElementsByClassName('cover')[0].style.display = ""; 
+    document.getElementsByClassName('l_body', 'show')[0].classList.remove("nocover"); 
+    document.getElementsByClassName('l_header', 'cover-wrapper')[0].classList.remove("show"); 
+  } 
+</script> 
 <% } %>

--- a/source/js/app.js
+++ b/source/js/app.js
@@ -205,7 +205,7 @@ var customSearch;
 	// 设置全局事件
 	function setGlobalHeaderMenuEvent() {
 		// PC端 hover时展开子菜单，点击时隐藏子菜单
-		$('.m-pc li').click(function (e) {
+		$('.m-pc li > a[href]').parent().click(function (e) {
 			e.stopPropagation();
 			$('.m-pc .list-v').hide();
 		});


### PR DESCRIPTION
- 1. 调整评论相关的 Front-matter 配置。
- 2. 调整全局评论下相关配置。
- 3. 重写 disqus 加载过程
- 4. 修复桌面端对存在二级菜单的一级按钮二次点击弹窗无法弹出的问题

  ```yml
  //Front-matter
  comment:
    enable: false
    url:  
    placeholder: 
   ```

  ```yml
  // config.yml
  comments:
    path:                    # 全局评论地址 仅支持 valine , miniValine , disqus , gitalk
    placeholder: 快来评论吧~  # 评论占位提示 仅支持 valine & miniValine
  ```

PS: 1. 2. 未经充分验证


 TODO：*基于 Disqus 的文章评论计数*