### PR TITLE
replace pathname

### DIFF
--- a/layout/_third-party/comments/waline/script.ejs
+++ b/layout/_third-party/comments/waline/script.ejs
@@ -10,7 +10,7 @@
     let path = pdata.commentPath;
     if (path.length == 0) {
       let defaultPath = '<%= theme.comments.waline.path %>';
-      path = defaultPath || decodeURI(window.location.pathname);
+      path = defaultPath || decodeURI(location.pathname.replace(/\/$/, '') );
     }
     new Waline(Object.assign(<%- JSON.stringify(theme.comments.waline) %>, {
      el: '#waline',


### PR DESCRIPTION
个别目录会自动给 URL 最后带一个 / 导致文章的唯一 id 有变化（这句话来自waline开发者），如hexo-douban-list2生成的movies目录，（补充：包括友链这种不带html而link是host/friends 这类）此外没发现其它影响。更改pathname之后正常且暂未发现异常，如果不必要可以忽略，因为原本是用的waline官方建议的值，这个更改只是解决个别问题。
path: location.pathname.replace(/\/$/, '')

## PR Checklist <!-- 我确认我已经查看了 -->

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] [Docs](https://github.com/volantis-x/community/) in [volantis website](https://volantis.js.org/)  have been added / updated (for features).

## PR Type
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->
解决个别状况waline无法正确加载评论的问题，此外使用无异常。
- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ]  (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 -->

Issue resolved: 

## What is the new behavior?
<!-- Description about this pull, in several words -->
<!-- 关于这个PR的新行为描述 -->


- Screenshots with this changes: 


- Link to demo site with this changes: 


### How to use?

```

```
