### PR TITLE
修正一处描述错误 dev

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -709,7 +709,7 @@ plugins:
     # 配置项按照yml格式继续填写即可
     appId: ogP8qj3veMh0LFpFWMPOyF0X-MdYXbMMI # your appID
     appKey: nHXLd3N3Jgh460t2iRQKWAtr # your appKEY
-    # serverURL:  #leancloud绑定的安全域名，使用国际版的话不需要填写
+    # serverURL:  #leancloud绑定的api访问域名，使用国际版的话不需要填写
     # lang: # 语言设置，zh为汉语，en为英语，es为西班牙语。默认为汉语
     # pageSize: #每页说说的显示数量
     # shuoPla: #在编辑说说的输入框中的占位符


### PR DESCRIPTION
使用国内版leancloud时，需要在artitalk的serverURL填入api访问域名而非安全域名。

## PR Checklist <!-- 我确认我已经查看了 -->

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [ ] 我已提交主题文档更新PR | [Docs](https://github.com/volantis-x/community/) in [volantis website](https://volantis.js.org/)  have been added / updated (for features).

## PR Type
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->


## Others

- Issue resolved: 

- Screenshots with this changes: 

- Link to demo site with this changes: 

