### PR TITLE
fix: fix Chinese urlencode displaying problem in permalink

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -1,5 +1,5 @@
 <article itemscope itemtype="http://schema.org/Article" class="article post white-box reveal md <%- theme.custom_css.body.effect.join(' ') %> article-type-<%= post.layout %>" id="<%= post.layout %>" itemscope itemprop="blogPost">
-  <link itemprop="mainEntityOfPage" href="<%- post.permalink %>">
+  <link itemprop="mainEntityOfPage" href="<%- decodeURI(post.permalink) %>">
   <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
     <meta itemprop="name" content="<%- config.title %>">
   </span>
@@ -69,7 +69,7 @@
           %>
           <div class="copyright license">
             <div class="license-title"><%- post.title %></div>
-            <div class="license-link"><a href="<%- page.permalink %>"><%- page.permalink %></a>
+            <div class="license-link"><a href="<%- decodeURI(page.permalink) %>"><%- decodeURI(page.permalink) %></a>
             </div>
             <div class="license-meta">
               <div class="license-meta-item">
@@ -106,7 +106,7 @@
             <blockquote>
               <% (footer_widget.copyright.content||[]).forEach(function(row){ %>
                 <% if (row == 'permalink') { %>
-                  <p><%- footer_widget.copyright.permalink %><a href=<%- page.permalink %>><%- page.permalink %></a></p>
+                  <p><%- footer_widget.copyright.permalink %><a href=<%- decodeURI(page.permalink) %>><%- decodeURI(page.permalink) %></a></p>
                 <% } else { %>
                   <%- markdown(row) %>
                 <% } %>

--- a/layout/_partial/post.ejs
+++ b/layout/_partial/post.ejs
@@ -1,5 +1,5 @@
 <div class="post post-v3 white-box reveal <%- theme.custom_css.body.effect.join(' ') %>"  itemscope itemtype="http://schema.org/Article" >
-  <link itemprop="mainEntityOfPage" href="<%- post.permalink %>">
+  <link itemprop="mainEntityOfPage" href="<%- decodeURI(post.permalink) %>">
   <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
     <meta itemprop="name" content="<%- config.title %>">
   </span>


### PR DESCRIPTION
replace post.permalink with decodeURI(post.permalink)
replace page.permalink with decodeURI(page.permalink)

## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [ x ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->

文章底部的永久分享链接里面，中文是urlencode形式的。hexo提供了decodeURI()函数，所以在引用到的相关地方调用了这个函数。

## Others

- Issue resolved: 

- Screenshots with this changes: 

![image](https://user-images.githubusercontent.com/96779663/182124122-16e2e751-8f25-4cf2-a91d-f23e18256fa7.png)

- Link to demo site with this changes: 

参考
* [hexo permalink中文乱码解决方案 | 最暖一天](https://changzhi.space/p/ccd1e516.html)