### PR TITLE
fix: 加引号处理href属性中空格导致的地址错误

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -106,7 +106,7 @@
             <blockquote>
               <% (footer_widget.copyright.content||[]).forEach(function(row){ %>
                 <% if (row == 'permalink') { %>
-                  <p><%- footer_widget.copyright.permalink %><a href=<%- decodeURI(page.permalink) %>><%- decodeURI(page.permalink) %></a></p>
+                  <p><%- footer_widget.copyright.permalink %><a href="<%- decodeURI(page.permalink) %>"><%- decodeURI(page.permalink) %></a></p>
                 <% } else { %>
                   <%- markdown(row) %>
                 <% } %>


### PR DESCRIPTION
## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [ x ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->
之前只是把permalink相关的地方加了一层decodeURI，但是刚刚发现，如果在文件路径中包含空格会导致显示正常，但是跳转错误。找了一下，发现原先的href属性里缺引号

## Others

- Issue resolved: 

- Screenshots with this changes: 

- Link to demo site with this changes: 

