### PR TITLE
友链朋友圈插件挂载id调整

### DIFF
--- a/layout/_plugins/_page_plugins/fcircle/index.ejs
+++ b/layout/_plugins/_page_plugins/fcircle/index.ejs
@@ -1,5 +1,5 @@
 <script>
-    volantis.layoutHelper("page-plugins", `<div id="app"></div>`, { pjax: false }) // 外层有 pjax 标签
+    volantis.layoutHelper("page-plugins", `<div id="hexo-circle-of-friends-root"></div>`, { pjax: false }) // 外层有 pjax 标签
 </script>
 <script>
     let UserConfig = {


### PR DESCRIPTION
## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
挂载id由`#app`替换为`#hexo-circle-of-friends-root`，见[友链朋友圈前端](https://github.com/hiltay/hexo-circle-of-friends-front/blob/master/src/main.js)


## Others

- Issue resolved: 

- Screenshots with this changes: 

- Link to demo site with this changes: 

