### PR TITLE
fix: wrong behavior when there's no img provided for qrcode

### DIFF
--- a/layout/_plugins/share/layout.ejs
+++ b/layout/_plugins/share/layout.ejs
@@ -1,7 +1,7 @@
 <div class="new-meta-item share -mob-share-list">
   <div class="-mob-share-list share-body">
     <% getList(theme.article.body.meta_library.share).forEach(function(item){ %>
-      <% if (item.id == 'qrcode'){ %>
+      <% if (item.id == 'qrcode' && (item.img || item.icon)){ %>
         <% var src = qrcode(url,{margin:1,size:8}); %>
         <div class='hoverbox'>
           <a class='share'><img src="<%- item.img %>"></a>


### PR DESCRIPTION
## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->

遵循如下配置文件来复现这个 bug：

```yml
article:
  # 文章列表页面的文章卡片布局方案
  preview:
    ...
  # 文章详情页面的文章卡片本体布局方案
  body:
    ...
    footer_widget:
      ...
      share:
        - id: qq
          img:  volantis-static/media/org.volantis/logo/128/qq.png #  https://cdn.jsdelivr.net/gh/volantis-x/cdn-org/logo/128/qq.png
        - id: qzone
          img: volantis-static/media/org.volantis/logo/128/qzone.png #  https://cdn.jsdelivr.net/gh/volantis-x/cdn-org/logo/128/qzone.png
        - id: weibo
          img: # volantis-static/media/org.volantis/logo/128/weibo.png #  https://cdn.jsdelivr.net/gh/volantis-x/cdn-org/logo/128/weibo.png
        - id: qrcode # 当id为qrcode时需要安装插件  npm i hexo-helper-qrcode
          img: # volantis-static/media/org.volantis/logo/128/wechat.png #  https://cdn.jsdelivr.net/gh/volantis-x/cdn-org/logo/128/wechat.png
        - id: # telegram
          img: # volantis-static/media/org.volantis/logo/128/telegram.png #  https://cdn.jsdelivr.net/gh/volantis-x/cdn-org/logo/128/telegram.
```

![图片](https://user-images.githubusercontent.com/14120445/211153813-4c322cbd-9321-42a7-82e1-4d1850422f1f.png)

可见微博 img 被注释后直接不再显示这个元素，而 qrcode 的 img 被注释后，则出现了如图的异常。

![图片](https://user-images.githubusercontent.com/14120445/211153878-b056450d-11d1-436d-97d0-f6f8457b0724.png)

这个 PR 修复了这个问题，让 qrcode 的表现与其它分享图标一致。

## Others

我在 2020 年 5 月开始使用此主题，2022 年 3 月从 Hexo 切换到了别的博客系统。当时我完全不懂编程，更别说前端开发。现在我的 GitHub 已经一大片绿，谨以此 PR 纪念这个陪伴我两年的主题，以及这个陪伴我两年的博客系统。

