### PR TITLE
Update _cdn.yml

### DIFF
--- a/_cdn.yml
+++ b/_cdn.yml
@@ -320,7 +320,7 @@ waline_css:
   name: "@waline/client"
   cdnjs_name: waline
   file: dist/waline.css
-  version: 3.0.0-alpha.8
+  version: 2.15.8
   npm: true
   static: false
   cdnjs: true
@@ -328,7 +328,7 @@ waline_js:
   name: "@waline/client"
   cdnjs_name: waline
   file: dist/waline.js
-  version: 3.0.0-alpha.8
+  version: 2.15.8
   npm: true
   static: false
   cdnjs: true


### PR DESCRIPTION
waline 3.0版本为测试版，暂不可用。建议改回2.15.8

