### PR TITLE
fix: 修复图片alt为空时Fancybox caption输出undefined的问题

### DIFF
--- a/scripts/tags/fancybox.js
+++ b/scripts/tags/fancybox.js
@@ -22,7 +22,7 @@ function buidImgFancybox(content, group) {
   let imgList = html.match(/<img.*?>/g) || [];
   imgList.forEach(item => {
     const url = (item.match(/\ssrc=['"](.*?)['"]/) || [])[1];
-    const alt = (item.match(/\salt=['"](.*?)['"]/) || [])[1];
+    const alt = (item.match(/\salt=['"](.*?)['"]/) || [])[1] || '';
     const newItem = item.replace('img', 'img fancybox itemprop="contentUrl"');  // 避免出现重复替换，打个标
     const result = `<div class='fancybox'><a class='fancybox' itemscope itemtype="https://schema.org.cn/ImageObject" itemprop="url" href='${url}' data-fancybox='${group}' data-caption='${alt}'>${newItem}</a>${buidAlt(imageTags || alt)}</div>`;
     html = html.replace(item, result.trim());


### PR DESCRIPTION
## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->

如果 `item.match()` 未匹配到结果，` || []` 会返回空数组，那么 `[1]` 就会输出 `undefined`
在后方提供一个空字符串 `''` 的默认值可以避免输出 `undefined`

## Others

- Issue resolved: 

- Screenshots with this changes: 

- Link to demo site with this changes: 

