### PR TITLE
fix: 修复waline v3的引入问题

### DIFF
--- a/layout/_plugins/comments/waline/script.ejs
+++ b/layout/_plugins/comments/waline/script.ejs
@@ -1,8 +1,11 @@
-<script>
-  volantis.layoutHelper("comments",`<div id="waline"><i class="fa-solid fa-cog fa-spin fa-fw fa-2x"></i></div>`)
-  
+<script type="module">
+  import { init } from '<%- theme.cdn.waline_js %>';
+
+  volantis.layoutHelper("comments", `<div id="waline"><i class="fa-solid fa-cog fa-spin fa-fw fa-2x"></i></div>`)
+
   function p_waline() {
-    if(!document.querySelector("#waline"))return;
+    if (!document.querySelector("#waline")) return;
+    
     let locale = {};
     let path = pdata.commentPath;
     let pagePlaceholder = pdata.commentPlaceholder || "<%= theme.comments.waline.placeholder %>";
@@ -10,12 +13,12 @@
       let defaultPath = '<%= theme.comments.waline.path %>';
       path = defaultPath || decodeURI(window.location.pathname);
     }
-    if(pagePlaceholder.length != 0) {
+    if (pagePlaceholder.length != 0) {
       locale.placeholder = pagePlaceholder;
     }
 
     try {
-      Waline.init(Object.assign(Object.assign(<%- JSON.stringify(theme.comments.waline) %>, {
+      init(Object.assign(Object.assign(<%- JSON.stringify(theme.comments.waline) %>, {
         el: '#waline',
         path: path,
         // https://github.com/volantis-x/hexo-theme-volantis/issues/713
@@ -24,38 +27,38 @@
             let headers = new Headers();
             headers.set('Accept', 'application/json');
             <% if(!!theme.comments.waline.imageUploader?.token) { %>
-              headers.set('<%= theme.comments.waline.imageUploader?.tokenName %>', '<%= theme.comments.waline.imageUploader?.token %>')
+              headers.set('<%= theme.comments.waline.imageUploader?.tokenName %>', '<%= theme.comments.waline.imageUploader?.token %>');
             <% } %>
             let formData = new FormData();
             formData.append('<%= theme.comments.waline.imageUploader?.fileName %>', file);
-            return fetch('<%= theme.comments.waline.imageUploader?.api %>',{
+            return fetch('<%= theme.comments.waline.imageUploader?.api %>', {
               method: 'POST',
               body: formData,
               headers: headers
-              }).then((resp) => resp.json())
-                .then((resp) => resp.<%= theme.comments.waline.imageUploader?.resp %>)
+            }).then((resp) => resp.json())
+              .then((resp) => resp.<%= theme.comments.waline.imageUploader?.resp %>);
           },
         <% } %>
         locale,
-      }),pdata.commentConfig));
+      }), pdata.commentConfig));
     } catch (error) {
-      alert(`Waline ${error}`)
+      alert(`Waline ${error}`);
     }
-    fancybox_waline()
+    fancybox_waline();
   }
 
   function fancybox_waline() {
-    if(typeof VolantisFancyBox === "undefined") {
+    if (typeof VolantisFancyBox === "undefined") {
       const checkFancyBox = setInterval(() => {
-        if(typeof VolantisFancyBox === "undefined") return;
+        if (typeof VolantisFancyBox === "undefined") return;
         clearInterval(checkFancyBox);
         VolantisFancyBox.bind('#waline .wl-content img:not(.wl-emoji)');
-      })
+      });
     } else {
       VolantisFancyBox.bind('#waline .wl-content img:not(.wl-emoji)');
     }
   }
 
-  volantis.css('<%= theme.cdn.waline_css %>')
-  volantis.js('<%- theme.cdn.waline_js %>').then(p_waline)
+  volantis.css('<%= theme.cdn.waline_css %>');
+  volantis.js('<%- theme.cdn.waline_js %>').then(p_waline);
 </script>


### PR DESCRIPTION
Waline v3 的使用方式发生了变化，需要通过 `import` 引入并使用 `init` 函数来初始化，而不是直接使用全局的 `Waline` 对象。

## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->

[Waline v3的引入方式](https://waline.js.org/guide/get-started/#html-%E5%BC%95%E5%85%A5-%E5%AE%A2%E6%88%B7%E7%AB%AF)发生了变化，需要使用新的方式初始化，不然会报错 `Waline ReferenceError: Waline is not defined`

## Changes

1. **引入 Waline 样式：**
   保持样式的引入不变，依旧可以通过配置文件引入 Waline 的文件。

2. **通过 `import` 方式加载 Waline 并使用 `init`：**
   - 将原先的 `Waline.init` 改为 `import { init } from '<%- theme.cdn.waline_js %>';`。
   - 使用 `init()` 来初始化 Waline 评论系统。

3. **保留现有的配置和逻辑：**
   - `path`, `locale`, `imageUploader` 等配置保留，并通过 `Object.assign()` 合并这些配置传递给 `init()`。

4. **移除全局的 `Waline` 对象：**
   由于 `Waline` 不再作为全局对象使用，直接通过 `import` 后使用 `init` 函数，解决了 "Waline is not defined" 的问题。
