### PR TITLE
fix: 对twikoo表情过多导致的表情栏被hidden

### DIFF
--- a/source/css/_style/_base/base.styl
+++ b/source/css/_style/_base/base.styl
@@ -67,7 +67,7 @@ article,aside,details,figcaption,figure,footer,hgroup,main,menu,nav,section,summ
   display: block
 
 article
-  overflow: hidden
+  overflow: visible
 
 abbr[title]
   border-bottom: 1px dotted


### PR DESCRIPTION
## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [x] Bugfix.
- [ ] Feature.
- [x] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->
更改 `overflow: hidden` → `overflow: visible`

原状：
![image](https://github.com/user-attachments/assets/a0b894cc-b429-4ef6-a516-4cb7b21656b6)

更改后：
![image](https://github.com/user-attachments/assets/4ed8ca70-e92f-4e76-b7ec-98794ada99bb)




## Others

- Issue resolved: 

- Screenshots with this changes: 


- Link to demo site with this changes: 

