### PR TITLE
fix: aplayer显示问题（2）

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -890,7 +890,7 @@ plugins:
         cover: '/music/Avem.jpg'
     # ============= local end ================
     # Optional
-    fixed: false      # enable fixed mode
+    fixed: false      # enable fixed mode 此处true会对footer与sidebar开启的aplayer造成影响
     theme: '#1BCDFC'  # main color
     autoplay: false   # audio autoplay
     order: list       # player play order, values: 'list', 'random'

--- a/layout/_partial/scripts/index.ejs
+++ b/layout/_partial/scripts/index.ejs
@@ -58,10 +58,10 @@
 
 <% if (theme.plugins.aplayer && theme.plugins.aplayer.enable) { %>
   <% if (!is_post() && !is_page()) { %>
-      <%- partial('../../_plugins/aplayer/script') %>
-      <% if (theme.plugins.aplayer.fixed == true ) { %>
-        <%- partial('../../_plugins/aplayer/layout', { post: page }) %>
-      <% } %>
+    <%- partial('../../_plugins/aplayer/script') %>
+    <% if (theme.plugins.aplayer.fixed == true ) { %>
+      <%- partial('../../_plugins/aplayer/layout', { post: page }) %>
+    <% } %>
   <% } %>
   <% if (is_post() || is_page()) { %>
     <%- partial('../../_plugins/aplayer/script') %>

--- a/layout/_partial/scripts/index.ejs
+++ b/layout/_partial/scripts/index.ejs
@@ -58,15 +58,15 @@
 
 <% if (theme.plugins.aplayer && theme.plugins.aplayer.enable) { %>
   <% if (!is_post() && !is_page()) { %>
-    <%- partial('../../_plugins/aplayer/script') %>
-    <%- partial('../../_plugins/aplayer/layout', { post: page }) %>
+      <%- partial('../../_plugins/aplayer/script') %>
+      <% if (theme.plugins.aplayer.fixed == true ) { %>
+        <%- partial('../../_plugins/aplayer/layout', { post: page }) %>
+      <% } %>
   <% } %>
   <% if (is_post() || is_page()) { %>
-    <% if (!page.music) { %>
-      <%- partial('../../_plugins/aplayer/script') %>
-      <%- partial('../../_plugins/aplayer/layout', { post: page }) %>
-    <% } else { %>
-      <%- partial('../../_plugins/aplayer/script') %>
+    <%- partial('../../_plugins/aplayer/script') %>
+    <% if (!page.music && theme.plugins.aplayer.fixed == true ) { %>
+        <%- partial('../../_plugins/aplayer/layout', { post: page }) %>
     <% } %>
   <% } %>
 <% } %>


### PR DESCRIPTION
## PR Type

<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->
<!-- What kind of change does this PR introduce? -->
<!-- PR带来了什么样的变化？ -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## Description
<!-- Please describe the current behavior you are modifying, or link to a related question to describe the new behavior about this pr -->
<!-- 请描述您正在修改的当前行为，或链接到相关问题 ，描述关于这个PR的新行为-->
![image](https://github.com/user-attachments/assets/e048cb91-a822-47cb-ba6b-53b922be807e)

在群友的发现下，发现之前改的代码的不足之处，因此这次特地来修补一下出现了两个aplayer的问题。新代码旨在通过判断是否开启吸底模式来修正行为，为什么要这样改？我的考虑是，既然打算把aplayer放footer等地方，就不该启用吸底模式，吸底模式是个全屏的嵌入，在footer等地方只是一个固定的地方，再者，多个music也都是分开调控的，既然这样，那么不如干脆吸底和footer等固定点进行二选一（？）

同时，顺便优化了一下源代码）

## Others

- Issue resolved: 

- Screenshots with this changes: 

- Link to demo site with this changes: 

