### PR TITLE
fix(md): 修复 md 标签中的错误引用和英文语法问题

### DIFF
--- a/scripts/tags/md.js
+++ b/scripts/tags/md.js
@@ -12,7 +12,7 @@ hexo.extend.tag.register('md', function(args) {
     const loadMarkdown = (url) => {
       if (!window.fetch) {
         contentEl.innerHTML =
-          '<div style="font-size: 24px"><p>Your browser outdated. Please use the latest version of Chrome or Firefox!</p><p>您的浏览器版本过低，请使用最新版的 Chrome 或 Firefox 浏览器！</p></div>';
+          '<div style="font-size: 24px"><p>Your browser is outdated. Please use the latest version of Chrome or Firefox!</p><p>您的浏览器版本过低，请使用最新版的 Chrome 或 Firefox 浏览器！</p></div>';
       } else {
         contentEl.innerHTML =
           '<div style="font-size: 24px">Loading ... | 加载中。。。</div>';
@@ -34,7 +34,7 @@ hexo.extend.tag.register('md', function(args) {
                 headers,
               };
             } else {
-              throw new Error(JSON.stringify(json.error));
+              throw new Error("Request failed with status " + status + ": " + data);
             }
           })
           .then((resp) => {


### PR DESCRIPTION
## Summary

- 修复 `md` 标签在 fetch 请求失败时引用未定义变量 `json` 导致的 `ReferenceError`，改为使用当前作用域内的 `status` 和 `data` 输出有意义的错误信息
- 修正英文提示文案 `"Your browser outdated"` → `"Your browser is outdated"`

## Details

当使用 `{% md URL %}` 标签加载远程 Markdown 文件时，如果 HTTP 请求返回非 200 状态码，原代码执行 `throw new Error(JSON.stringify(json.error))`，但当前作用域中并不存在 `json` 变量（只有 `ok`、`status`、`data`、`headers`），导致抛出 `ReferenceError: json is not defined`，掩盖了真实的请求失败原因。

修复后会输出 `Request failed with status {status}: {data}`，便于定位问题。

Made with [Cursor](https://cursor.com)